### PR TITLE
Final reformat gexpnn

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,4 +161,5 @@ bash wrapper_ftset-gexpnn.sh ../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/Features-20
 
 Results column in file `nn_jg_2020-03-20|nn_jg_2020-03-20_top1kfreq|2020-03-20|p`
 TODO:
-- [ ]
+- [ ] convert from prob to crisp predictions (ACC:ACC_2)
+- [ ] update model col header: p --> c, add TUMOR:____ prefix, add time stamp where is 2020-03-20 --> 2020-03-20T00:00.00.000 (will just pick time 00 for timestamp)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ bash wrapper_ftset-gexpnn.sh ../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/Features-20
 
 Results column in file `nn_jg_2020-03-20|nn_jg_2020-03-20_top1kfreq|2020-03-20|p`
 TODO:
-- [ ] convert from prob to crisp predictions (ACC:ACC_2)
-- [ ] convert Label col entries ACC:2 --> ACC:ACC_2
-- [ ] update model col header: p --> c, add TUMOR:____ prefix, add time stamp where is 2020-03-20 --> 2020-03-20T00:00.00.000 (will just pick time 00 for timestamp)
+- [x] convert from prob to crisp predictions (ACC:ACC_2)
+- [x] convert Label col entries ACC:2 --> ACC:ACC_2
+- [x] update model col header: p --> c
+- [ ] updat header add TUMOR:____ prefix, add time stamp where is 2020-03-20 --> 2020-03-20T00:00.00.000 (will just pick time 00 for timestamp)

--- a/README.md
+++ b/README.md
@@ -137,5 +137,5 @@ outputs `data/library_reformating/predictions_reformatted_gnosis20200408-${tumor
 
 # Reformat GEXP_NN files (2020-03-20-allCOHORTS_20200203Tarball_JasleenGrewal)
 
-- [] Reformat GEXP_NN feature set files
-- [] Reformat GEXP_NN prediction matrices
+- [ ] Reformat GEXP_NN feature set files
+- [ ] Reformat GEXP_NN prediction matrices

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ outputs `data/library_reformating/predictions_reformatted_gnosis20200408-${tumor
 
 # Reformat GEXP_NN files (2020-03-20-allCOHORTS_20200203Tarball_JasleenGrewal)
 
-- [ ] Reformat GEXP_NN feature set file
+- [x] Reformat GEXP_NN feature set file
 - [ ] Reformat GEXP_NN prediction matrices
 
 
@@ -146,7 +146,12 @@ outputs `data/library_reformating/predictions_reformatted_gnosis20200408-${tumor
 Raw file contains 2 different feature sets (nn_jg_2020-03-20_bootstrapfeatures,nn_jg_2020-03-20_top1kfreq)
 
 TODO:
-- [ ] Remove # commented out lines at head of file (specific to viewer input)
-- [ ] Remove Feature_importances col (specific to viewer input)
-- [ ] col TCGA_Projects -- ' -> " and rm spaces between list items
-- [ ] col Features -- "['ft', 'ft', ...]" -> ["ft","ft",..]
+- [x] Remove # commented out lines at head of file (specific to viewer input)
+- [x] Remove Feature_importances col (specific to viewer input)
+- [x] col TCGA_Projects -- ' -> " and rm spaces between list items
+- [x] col Features -- "['ft', 'ft', ...]" -> ["ft","ft",..]
+
+```
+cd reformat
+bash wrapper_ftset-gexpnn.sh ../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/Features-20200320_allCOHORTS_20200203Tarball_JasleenGrewal.txt ../data/library_reformating/features_reformatted_gexpnn20200320allCOHORTS.tsv
+```

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ outputs `data/library_reformating/predictions_reformatted_gnosis20200408-${tumor
 Raw file contains 2 different feature sets (nn_jg_2020-03-20_bootstrapfeatures,nn_jg_2020-03-20_top1kfreq)
 
 TODO:
+- [x] Remove row on `nn_jg_2020-03-20_bootstrapfeatures` because this feature_set_id is not present in prediction file (viewer requires all featuresets in file to also be in prediction file)
 - [x] Remove # commented out lines at head of file (specific to viewer input)
 - [x] Remove Feature_importances col (specific to viewer input)
 - [x] col TCGA_Projects -- ' -> " and rm spaces between list items
@@ -155,3 +156,9 @@ TODO:
 cd reformat
 bash wrapper_ftset-gexpnn.sh ../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/Features-20200320_allCOHORTS_20200203Tarball_JasleenGrewal.txt ../data/library_reformating/features_reformatted_gexpnn20200320allCOHORTS.tsv
 ```
+
+1. Reformat GEXP_NN prediction files
+
+Results column in file `nn_jg_2020-03-20|nn_jg_2020-03-20_top1kfreq|2020-03-20|p`
+TODO:
+- [ ]

--- a/README.md
+++ b/README.md
@@ -134,3 +134,8 @@ cd reformat
 ```
 
 outputs `data/library_reformating/predictions_reformatted_gnosis20200408-${tumor}.tsv`
+
+# Reformat GEXP_NN files (2020-03-20-allCOHORTS_20200203Tarball_JasleenGrewal)
+
+- [] Reformat GEXP_NN feature set files
+- [] Reformat GEXP_NN prediction matrices

--- a/README.md
+++ b/README.md
@@ -137,5 +137,16 @@ outputs `data/library_reformating/predictions_reformatted_gnosis20200408-${tumor
 
 # Reformat GEXP_NN files (2020-03-20-allCOHORTS_20200203Tarball_JasleenGrewal)
 
-- [ ] Reformat GEXP_NN feature set files
+- [ ] Reformat GEXP_NN feature set file
 - [ ] Reformat GEXP_NN prediction matrices
+
+
+1. Reformat GEXP_NN feature set file
+
+Raw file contains 2 different feature sets (nn_jg_2020-03-20_bootstrapfeatures,nn_jg_2020-03-20_top1kfreq)
+
+TODO:
+- [ ] Remove # commented out lines at head of file (specific to viewer input)
+- [ ] Remove Feature_importances col (specific to viewer input)
+- [ ] col TCGA_Projects -- ' -> " and rm spaces between list items
+- [ ] col Features -- "['ft', 'ft', ...]" -> ["ft","ft",..]

--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ cd reformat
 bash wrapper_ftset-gexpnn.sh ../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/Features-20200320_allCOHORTS_20200203Tarball_JasleenGrewal.txt ../data/library_reformating/features_reformatted_gexpnn20200320allCOHORTS.tsv
 ```
 
-1. Reformat GEXP_NN prediction files
+2. Reformat GEXP_NN prediction files
 
 Results column in file `nn_jg_2020-03-20|nn_jg_2020-03-20_top1kfreq|2020-03-20|p`
 TODO:
 - [ ] convert from prob to crisp predictions (ACC:ACC_2)
+- [ ] convert Label col entries ACC:2 --> ACC:ACC_2
 - [ ] update model col header: p --> c, add TUMOR:____ prefix, add time stamp where is 2020-03-20 --> 2020-03-20T00:00.00.000 (will just pick time 00 for timestamp)

--- a/README.md
+++ b/README.md
@@ -159,9 +159,19 @@ bash wrapper_ftset-gexpnn.sh ../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/Features-20
 
 2. Reformat GEXP_NN prediction files
 
+Decided to sep into individual tumor files (viewer requires this input), note that GEXP_NN is a pan-cancer method not a tumor level method
+
 Results column in file `nn_jg_2020-03-20|nn_jg_2020-03-20_top1kfreq|2020-03-20|p`
+
 TODO:
 - [x] convert from prob to crisp predictions (ACC:ACC_2)
 - [x] convert Label col entries ACC:2 --> ACC:ACC_2
 - [x] update model col header: p --> c
-- [ ] updat header add TUMOR:____ prefix, add time stamp where is 2020-03-20 --> 2020-03-20T00:00.00.000 (will just pick time 00 for timestamp)
+- [x] one unified file --> split files for each cancer type (just note this method applied a pan-cancer approach even though we are spliting by tumor)
+- [x] updat header add TUMOR:____ prefix, add time stamp where is 2020-03-20 --> 2020-03-20T00:00.00.000 (will just pick time 00 for timestamp)
+
+
+```
+cd reformat
+bash wrapper_preds-gexpnn.sh ../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/2020-03-20-allCOHORTS_20200203Tarball_JasleenGrewal TEMP_DIR ../data/library_reformating
+```

--- a/reformat/reformat-gexpnn-ftset.py
+++ b/reformat/reformat-gexpnn-ftset.py
@@ -1,0 +1,52 @@
+#!/bin/bash/env python3
+
+## Purpose = reformat the feature files of gnosis.
+
+import os
+import argparse
+
+def get_arguments():
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument("-in", "--input", help ="input dir", required=True, type=str)
+    parser.add_argument("-out", "--output", help ="output dir", required=True, type=str)
+    return parser.parse_args()
+
+args = get_arguments()
+ft_input = args.input
+ft_output = args.output
+
+
+# Reformat and save tsv outputs
+with open(ft_input, 'r') as fh, open(ft_output, 'w') as out:
+    irow = 0
+    for line in fh:
+        # skip any commented lines
+        if line.startswith("#"):
+            continue
+        # Write col headers to out
+        if irow == 0:
+            line = line.split('\t')
+            print(line[1])
+            out.write(line[0]+'\t'+line[1]+'\t'+line[2]+"\n")
+            irow+=1
+        else:
+            line = line.strip().split('\t')
+            ftmethod = line[0]
+            tumor = line[1]
+            ftset = line[2]
+
+            # No reformat to ftmethod
+            ftmethod = 'model' + ftmethod
+            out.write(ftmethod + '\t')
+
+            # reformat tumor
+            tumor = tumor.strip("[").strip("]").replace("'", '"').replace(" ","")
+            tumor = "[" + tumor + "]"
+            out.write(tumor + '\t')
+
+            # reformat ftset
+            ftset = ftset.replace("'", '"').replace(" ","")
+            out.write(ftset + "\n")
+
+
+print("Created file: ", ft_output)

--- a/reformat/reformat-gexpnn-ftset.py
+++ b/reformat/reformat-gexpnn-ftset.py
@@ -24,11 +24,14 @@ with open(ft_input, 'r') as fh, open(ft_output, 'w') as out:
         if line.startswith("#"):
             continue
         # Write col headers to out
-        if irow == 0:
+        elif irow == 0:
             line = line.split('\t')
             print(line[1])
             out.write(line[0]+'\t'+line[1]+'\t'+line[2]+"\n")
-            irow+=1
+            irow=1
+        #skip row 1 because this feature setid not present in prediction file
+        elif irow == 1:
+            irow=2
         else:
             line = line.strip().split('\t')
             ftmethod = line[0]

--- a/reformat/reformat-gexpnn-ftset.py
+++ b/reformat/reformat-gexpnn-ftset.py
@@ -39,7 +39,6 @@ with open(ft_input, 'r') as fh, open(ft_output, 'w') as out:
             ftset = line[2]
 
             # No reformat to ftmethod
-            ftmethod = 'model' + ftmethod
             out.write(ftmethod + '\t')
 
             # reformat tumor

--- a/reformat/reformat-gexpnn-preds-STEP1B.py
+++ b/reformat/reformat-gexpnn-preds-STEP1B.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+
+ft_input='TEMP_DIR/tmp-predictions_reformatted_gexpnn20200320allCOHORTS.tsv'
+
+df = pd.read_csv(ft_input,sep='\t')
+
+# Get all tumors present in df (ACC, BRCA, ...)
+temp = df['Label'].unique()
+u_tumor = {} #k=tumor, v=1
+for t in temp:
+    t= t.split(":")[0]
+    if t not in u_tumor:
+        u_tumor[t]=1
+
+# write out files for each tumor
+for t in u_tumor:
+    print('starting ', t)
+    subset  = df[df['Label'].str.contains(t)]
+    subset.to_csv('TEMP_DIR/intermediat-'+t+".tsv",sep='\t',index=False)

--- a/reformat/reformat-gexpnn-preds-STEP2.py
+++ b/reformat/reformat-gexpnn-preds-STEP2.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+## Purpose to run after reformat-gnosis-preds.py
+
+import os
+import glob
+
+import argparse
+
+def get_arguments():
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument("-in", "--input", help ="input dir", required=True, type=str)
+    parser.add_argument("-out", "--output", help ="output dir", required=True, type=str)
+    return parser.parse_args()
+
+args = get_arguments()
+ft_input = args.input
+ft_output = args.output
+
+
+# Read in all feature files from input dir
+os.chdir(ft_input)
+files = glob.glob('intermediat-*.tsv')
+
+
+os.chdir(ft_output)
+# Iterate through all files in a dir
+for f in files:
+    # set up file names
+    tumor = f.strip().split("-")[1].split('.')[0] #a== ACC/etc
+    outputname = "predictions_reformatted_gexpnn20200320allCOHORTS-" + tumor + ".tsv"
+
+    # Iterate through one file
+    with open(ft_input+"/"+f, 'r') as fh, open(outputname, 'w') as out:
+        irow = 0
+        for line in fh:
+            # Write col headers to out
+            if irow == 0:
+                line = line.strip().split('\t')
+                nmodels = len(line)
+                samp = line[0]
+                repeat = line[1]
+                fold = line[2]
+                test = line[3]
+                label = line[4]
+                # No reformat all meta data cols
+                out.write(samp + '\t' + repeat + '\t'  + fold + '\t'  + test + '\t'  + label)
+
+                # reformat all models
+                for i in range(5, nmodels):
+                    header = line[i]
+                    classifer = header.split('|')[0]
+                    ftmethod = header.split('|')[1].strip("\"")
+                    temporal = header.split('|')[2]
+                    crisp = header.split('|')[3]
+
+                    # Add tumor:classifer
+                    classifer = tumor+":"+classifer
+
+                    #fix temporal. 2020-03-13 -> 2020-03-13T00:00:00.000
+                    temporal = temporal + "T00:00:00.000"
+
+                    newline = classifer+ "|"+ftmethod+"|"+temporal+"|"+crisp
+                    out.write('\t' + newline)
+
+                out.write('\n')
+                irow+=1
+            else:
+                out.write(line)
+                
+    print('Created new file: ', outputname)

--- a/reformat/reformat-gexpnn-preds.py
+++ b/reformat/reformat-gexpnn-preds.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+#######
+# Imports and functions
+#######
+
+import json
+import pandas as pd
+import argparse
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument("-in", "--input", help ="name of input file", required=True, type=str)
+    parser.add_argument("-out", "--output", help ="name of output file", required=True, type=str)
+    return parser.parse_args()
+
+args = get_arguments()
+pred_file = args.input
+output_name = args.output
+
+
+
+def prob2crisp(name):
+    """
+    input one model name that will convert last bit of p to c
+    """
+    new_model_name = name.split('|')[: -1]
+    new_model_name.append('c')#add c for crisp
+    new_model_name = '|'.join(new_model_name)
+    return new_model_name
+
+def qc_prediction(PREDICTION_C):
+    import re
+    # 1. Search and remove class if in string. classACC:2 -> ACC:2
+    wrong = re.match('class', PREDICTION_C)
+    if wrong:
+        PREDICTION_C = re.sub('class', '', PREDICTION_C)
+        #print(PREDICTION_C)
+
+    # 2. Search and replace subtype name. ACC:2 -> ACC:ACC_2
+    tumor, subtype = re.split(r":", PREDICTION_C)
+    if tumor not in subtype:
+        PREDICTION_C = re.sub(subtype, tumor+"_"+subtype, PREDICTION_C)
+        #print(PREDICTION_C)
+    return PREDICTION_C
+
+
+#####
+# Read in
+#####
+# Read in file
+raw_pred = pd.read_csv(pred_file, skiprows=6, sep='\t')
+# raw_pred = pd.read_csv(pred_file, skiprows=4178, sep='\t', index_col=0)
+#raw_pred
+
+
+#####
+# Create template of new file of crisp predictions
+#####
+matrix_crisp = raw_pred.iloc[:, :4]
+#check format Labels col. ACC:2 -> ACC:ACC_2
+tmp = []
+for i in raw_pred["Label"]:
+    if i != qc_prediction(i):
+        i = qc_prediction(i)
+        tmp.append(i)
+    else:
+        tmp.append(i)
+#add Label col to matrix
+matrix_crisp['Label']= tmp
+#matrix_crisp
+
+
+######
+# Create crisp matrix
+######
+# create df of just model predictions
+df = raw_pred.iloc[:,5:]
+
+models = df.columns
+
+col_ct = 0 # debugging
+row_ct = 0 # debugging
+
+for m in models:
+    #print("###", i, "###")
+    # get crisp label from probabilites in a given cell
+    new_col = []
+    for row in df[m]:
+        #print(row)
+        row = row.replace("'", '"')
+        contents_dict = json.loads(row)
+        for k,v in contents_dict.items():
+            if k=='classification':
+                #print(v)
+                subtype_crisp = max(v, key=v.get)
+                subtype_crisp = qc_prediction(subtype_crisp)
+                #print(subtype_crisp)
+                new_col.append(subtype_crisp)
+
+        row_ct+=1
+    #add crisp to matrix_crisp
+    i = prob2crisp(m)
+    matrix_crisp[i] = new_col
+
+    col_ct+=1
+
+
+#rename col
+matrix_crisp=matrix_crisp.rename(columns = {'Unnamed: 0':'Sample_ID'})
+# save output
+matrix_crisp.to_csv(output_name, sep='\t', index=False)

--- a/reformat/wrapper_ftset-gexpnn.sh
+++ b/reformat/wrapper_ftset-gexpnn.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+raw_file=${1} #../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/Features-20200320_allCOHORTS_20200203Tarball_JasleenGrewal.txt
+output_file=${2} #../data/library_reformating/features_reformatted_gexpnn20200320allCOHORTS.tsv
+
+# 1. reformat feature file
+python reformat-gexpnn-ftset.py \
+    -in ${raw_file} \
+    -out ${output_file}
+
+echo 'Created file: '${output_file}

--- a/reformat/wrapper_preds-gexpnn.sh
+++ b/reformat/wrapper_preds-gexpnn.sh
@@ -13,12 +13,16 @@ python3 reformat-gexpnn-preds.py \
     -in ${raw_file} \
     -out ${temp_dir}/tmp-predictions_reformatted_gexpnn20200320allCOHORTS.tsv
 
+# Break full file into indivi tumor files
+echo 'splitting by tumor'
+python3 reformat-gexpnn-preds-STEP1B.py
 
-# # Reformat step 2: 2020-03-13 08:17:44.059 -> 2020-03-13T08:17:44.059, add "model" infront of model int
-# echo 'Starting reformat step 2'
-# python3 reformat-gexpnn-preds-STEP2.py \
-#     -in ${temp_dir} \
-#     -out ${output_dir}
-# 
-# echo 'Cleaning up workspace'
-# rm -r ${temp_dir}
+
+# Reformat step 2: 2020-03-13 08:17:44.059 -> 2020-03-13T08:17:44.059, add "model" infront of model int
+echo 'Starting reformat step 2'
+python3 reformat-gexpnn-preds-STEP2.py \
+    -in ${temp_dir} \
+    -out ${output_dir}
+
+echo 'Cleaning up workspace'
+rm -r ${temp_dir}

--- a/reformat/wrapper_preds-gexpnn.sh
+++ b/reformat/wrapper_preds-gexpnn.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+raw_file=${1} #../data/GROUP_RESULTS_RAW_FINAL/GEXP_NN/2020-03-20-allCOHORTS_20200203Tarball_JasleenGrewal
+temp_dir=${2} #./TEMP_DIR
+output_dir=${3} #../data/library_reformating
+
+mkdir ${temp_dir}
+
+# Reformat step 1: convert prob > crips predictions, classACC:2 or ACC:2 -> ACC:ACC_2
+    # TODO : add loop to process all files
+echo 'starting reformat step 1'
+python3 reformat-gexpnn-preds.py \
+    -in ${raw_file} \
+    -out ${temp_dir}/tmp-predictions_reformatted_gexpnn20200320allCOHORTS.tsv
+
+
+# # Reformat step 2: 2020-03-13 08:17:44.059 -> 2020-03-13T08:17:44.059, add "model" infront of model int
+# echo 'Starting reformat step 2'
+# python3 reformat-gexpnn-preds-STEP2.py \
+#     -in ${temp_dir} \
+#     -out ${output_dir}
+# 
+# echo 'Cleaning up workspace'
+# rm -r ${temp_dir}


### PR DESCRIPTION
1. Reformat GEXP_NN feature set file

Raw file contains 2 different feature sets (nn_jg_2020-03-20_bootstrapfeatures,nn_jg_2020-03-20_top1kfreq)

TODO:
- [x] Remove row on `nn_jg_2020-03-20_bootstrapfeatures` because this feature_set_id is not present in prediction file (viewer requires all featuresets in file to also be in prediction file)
- [x] Remove # commented out lines at head of file (specific to viewer input)
- [x] Remove Feature_importances col (specific to viewer input)
- [x] col TCGA_Projects -- ' -> " and rm spaces between list items
- [x] col Features -- "['ft', 'ft', ...]" -> ["ft","ft",..]

2. Reformat GEXP_NN prediction files

Decided to sep into individual tumor files (viewer requires this input), note that GEXP_NN is a pan-cancer method not a tumor level method

Results column in file `nn_jg_2020-03-20|nn_jg_2020-03-20_top1kfreq|2020-03-20|p`

TODO:
- [x] convert from prob to crisp predictions (ACC:ACC_2)
- [x] convert Label col entries ACC:2 --> ACC:ACC_2
- [x] update model col header: p --> c
- [x] one unified file --> split files for each cancer type (just note this method applied a pan-cancer approach even though we are spliting by tumor)
- [x] updat header add TUMOR:____ prefix, add time stamp where is 2020-03-20 --> 2020-03-20T00:00.00.000 (will just pick time 00 for timestamp)